### PR TITLE
Remove the reference to randombytes_salsa20_random.c from sugar.cmake…

### DIFF
--- a/src/libsodium/sugar.cmake
+++ b/src/libsodium/sugar.cmake
@@ -155,11 +155,6 @@ if(NOT LIBSODIUM_ENABLE_MINIMAL_BUILD)
   )
 endif()
 
-sugar_files(
-    LIBSODIUM_SOURCES
-    randombytes/salsa20/randombytes_salsa20_random.c
-)
-
 if(NOT EMSCRIPTEN)
   if(LIBSODIUM_NATIVE)
     sugar_files(


### PR DESCRIPTION
… as it is no longer in the source tree